### PR TITLE
fixing the errors coming up in the pydantic branch

### DIFF
--- a/template/steps/deploying/{% if deploy_to_skypilot %}skypilot_deployment.py{% endif %}
+++ b/template/steps/deploying/{% if deploy_to_skypilot %}skypilot_deployment.py{% endif %}
@@ -1,11 +1,7 @@
 # {% include 'template/license_header' %}
 
-from typing import Optional, List
-
 import os
 import re
-import sky
-from huggingface_hub import create_branch, login, HfApi
 
 from zenml import step
 from zenml.client import Client
@@ -16,14 +12,15 @@ logger = get_logger(__name__)
 
 
 @step()
-def deploy_to_skypilot(
-):
+def deploy_to_skypilot():
     """
     This step deploy the model to a VM using SkyPilot.
 
     This step requires `skypilot` to be installed.
-    aswell as a configured cloud account locally (e.g. AWS, GCP, Azure).
+    as well as a configured cloud account locally (e.g. AWS, GCP, Azure).
     """
+    import sky
+
     ### ADD YOUR OWN CODE HERE - THIS IS JUST AN EXAMPLE ###
     zenml_repo_root = Client().root
     if not zenml_repo_root:

--- a/template/steps/promotion/{% if metric_compare_promotion %}promote_metric_compare_promoter.py{% endif %}
+++ b/template/steps/promotion/{% if metric_compare_promotion %}promote_metric_compare_promoter.py{% endif %}
@@ -14,8 +14,8 @@ model_registry = Client().active_stack.model_registry
 
 @step
 def promote_metric_compare_promoter(
-    latest_metrics: Dict[str, str],
-    current_metrics: Dict[str, str],
+    latest_metrics: Dict[str, Any],
+    current_metrics: Dict[str, Any],
     metric_to_compare: str = "accuracy",
 ):
     """Try to promote trained model.


### PR DESCRIPTION
- There was a mismatch between the output signature of a step and the input signature of the next step.
- Steps are being imported, even in the local case. I moved the `import sky` within the step, so it will not fail for people trying the template locally without skypilot.