### PR TITLE
Huggingface fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,5 +56,5 @@ jobs:
         with:
           stack-name: ${{ matrix.stack-name }}
           python-version: ${{ matrix.python-version }}
-          ref-zenml: ${{ inputs.ref-zenml || 'develop' }}
+          ref-zenml: ${{ inputs.ref-zenml || 'bugfix/cleaning-up-the-ci-again' }}
           ref-template: ${{ inputs.ref-template || github.ref }}

--- a/template/steps/training/model_trainer.py
+++ b/template/steps/training/model_trainer.py
@@ -101,7 +101,7 @@ def model_trainer(
         per_device_eval_batch_size=eval_batch_size,
         num_train_epochs=num_epochs,
         weight_decay=weight_decay,
-        evaluation_strategy='steps',
+        eval_strategy='steps',
         save_strategy='steps',
         save_steps=1000,
         eval_steps=100,


### PR DESCRIPTION
evaluation_strategy is deprecated and was removed in version 4.46 of 🤗 Transformers. Used eval_strategy instead.